### PR TITLE
DOC: Edited examples of pad_width in arraypad.py

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -668,26 +668,26 @@ def pad(array, pad_width, mode='constant', **kwargs):
     Examples
     --------
     >>> a = [1, 2, 3, 4, 5]
-    >>> np.pad(a, (2, 3), 'constant', constant_values=(4, 6))
+    >>> np.pad(a, [2, 3], 'constant', constant_values=(4, 6))
     array([4, 4, 1, ..., 6, 6, 6])
 
-    >>> np.pad(a, (2, 3), 'edge')
+    >>> np.pad(a, [2, 3], 'edge')
     array([1, 1, 1, ..., 5, 5, 5])
 
-    >>> np.pad(a, (2, 3), 'linear_ramp', end_values=(5, -4))
+    >>> np.pad(a, [2, 3], 'linear_ramp', end_values=(5, -4))
     array([ 5,  3,  1,  2,  3,  4,  5,  2, -1, -4])
 
-    >>> np.pad(a, (2,), 'maximum')
+    >>> np.pad(a, [2,], 'maximum')
     array([5, 5, 1, 2, 3, 4, 5, 5, 5])
 
-    >>> np.pad(a, (2,), 'mean')
+    >>> np.pad(a, [2,], 'mean')
     array([3, 3, 1, 2, 3, 4, 5, 3, 3])
 
-    >>> np.pad(a, (2,), 'median')
+    >>> np.pad(a, [2,], 'median')
     array([3, 3, 1, 2, 3, 4, 5, 3, 3])
 
     >>> a = [[1, 2], [3, 4]]
-    >>> np.pad(a, ((3, 2), (2, 3)), 'minimum')
+    >>> np.pad(a, ([3, 2], [2, 3]), 'minimum')
     array([[1, 1, 1, 2, 1, 1, 1],
            [1, 1, 1, 2, 1, 1, 1],
            [1, 1, 1, 2, 1, 1, 1],
@@ -697,19 +697,19 @@ def pad(array, pad_width, mode='constant', **kwargs):
            [1, 1, 1, 2, 1, 1, 1]])
 
     >>> a = [1, 2, 3, 4, 5]
-    >>> np.pad(a, (2, 3), 'reflect')
+    >>> np.pad(a, [2, 3], 'reflect')
     array([3, 2, 1, 2, 3, 4, 5, 4, 3, 2])
 
-    >>> np.pad(a, (2, 3), 'reflect', reflect_type='odd')
+    >>> np.pad(a, [2, 3], 'reflect', reflect_type='odd')
     array([-1,  0,  1,  2,  3,  4,  5,  6,  7,  8])
 
-    >>> np.pad(a, (2, 3), 'symmetric')
+    >>> np.pad(a, [2, 3], 'symmetric')
     array([2, 1, 1, 2, 3, 4, 5, 5, 4, 3])
 
-    >>> np.pad(a, (2, 3), 'symmetric', reflect_type='odd')
+    >>> np.pad(a, [2, 3], 'symmetric', reflect_type='odd')
     array([0, 1, 1, 2, 3, 4, 5, 5, 6, 7])
 
-    >>> np.pad(a, (2, 3), 'wrap')
+    >>> np.pad(a, [2, 3], 'wrap')
     array([4, 5, 1, 2, 3, 4, 5, 1, 2, 3])
 
     >>> def pad_with(vector, pad_width, iaxis, kwargs):

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -671,23 +671,23 @@ def pad(array, pad_width, mode='constant', **kwargs):
     >>> np.pad(a, [2, 3], 'constant', constant_values=(4, 6))
     array([4, 4, 1, ..., 6, 6, 6])
 
-    >>> np.pad(a, [2, 3], 'edge')
-    array([1, 1, 1, ..., 5, 5, 5])
+    >>> np.pad(a, [2,], 'edge')
+    array([1, 1, 1, 2, 3, 4, 5, 5, 5])
 
-    >>> np.pad(a, [2, 3], 'linear_ramp', end_values=(5, -4))
-    array([ 5,  3,  1,  2,  3,  4,  5,  2, -1, -4])
+    >>> np.pad(a, 2, 'linear_ramp', end_values=(5, -4))
+    array([ 5,  3,  1,  2,  3,  4,  5,  0, -4])
 
-    >>> np.pad(a, [2,], 'maximum')
-    array([5, 5, 1, 2, 3, 4, 5, 5, 5])
+    >>> np.pad(a, 1, 'maximum')
+    array([5, 1, 2, 3, 4, 5])
 
     >>> np.pad(a, [2,], 'mean')
     array([3, 3, 1, 2, 3, 4, 5, 3, 3])
 
-    >>> np.pad(a, [2,], 'median')
-    array([3, 3, 1, 2, 3, 4, 5, 3, 3])
+    >>> np.pad(a, [1, 3], 'median')
+    array([3, 3, 3, 1, 2, 3, 4, 5, 3, 3, 3])
 
     >>> a = [[1, 2], [3, 4]]
-    >>> np.pad(a, ([3, 2], [2, 3]), 'minimum')
+    >>> np.pad(a, [[3, 2], [2, 3]], 'minimum')
     array([[1, 1, 1, 2, 1, 1, 1],
            [1, 1, 1, 2, 1, 1, 1],
            [1, 1, 1, 2, 1, 1, 1],
@@ -697,8 +697,8 @@ def pad(array, pad_width, mode='constant', **kwargs):
            [1, 1, 1, 2, 1, 1, 1]])
 
     >>> a = [1, 2, 3, 4, 5]
-    >>> np.pad(a, [2, 3], 'reflect')
-    array([3, 2, 1, 2, 3, 4, 5, 4, 3, 2])
+    >>> np.pad(a, [3,], 'reflect')
+    array([4, 3, 2, 1, 2, 3, 4, 5, 4, 3, 2])
 
     >>> np.pad(a, [2, 3], 'reflect', reflect_type='odd')
     array([-1,  0,  1,  2,  3,  4,  5,  6,  7,  8])
@@ -709,8 +709,8 @@ def pad(array, pad_width, mode='constant', **kwargs):
     >>> np.pad(a, [2, 3], 'symmetric', reflect_type='odd')
     array([0, 1, 1, 2, 3, 4, 5, 5, 6, 7])
 
-    >>> np.pad(a, [2, 3], 'wrap')
-    array([4, 5, 1, 2, 3, 4, 5, 1, 2, 3])
+    >>> np.pad(a, 1, 'wrap')
+    array([5, 1, 2, 3, 4, 5, 1])
 
     >>> def pad_with(vector, pad_width, iaxis, kwargs):
     ...     pad_value = kwargs.get('padder', 10)


### PR DESCRIPTION
fixes 
numpy/numpy#22340

made changes in numpy/lib/arraypad.py, specifically the numpy.pad function
- modified examples to follow the documented API

testing
ran numpy/lib/tests/test_arraypad.py without error